### PR TITLE
Fix "systemctl enable" issue with symbolic link

### DIFF
--- a/service/install.sh
+++ b/service/install.sh
@@ -10,7 +10,7 @@ TARGET="/etc/systemd/system/lnd-auto-backup.service"
 SOURCE="$SERVICE_DIR/lnd-auto-backup.service"
 
 set -x
-sudo ln -s ${SOURCE} ${TARGET}
+sudo cp ${SOURCE} ${TARGET}
 
 sudo chmod 755 /etc/systemd/system/lnd-auto-backup.service
 sudo systemctl daemon-reload


### PR DESCRIPTION
The `install.sh` script creates a symbolic link from `lnd-auto-backup.service` to the systemd service directory `/etc/systemd/system`.

When running the `enable.sh` script, it fails like this on my setup (Ubuntu 18.04):
`Failed to execute operation: Too many levels of symbolic links`

This is because systemd tries to create a symbolic link from `/etc/systemd/system/lnd-auto-backup.service` to `/etc/systemd/system/multi-user.target.wants/lnd-auto-backup.service`.

As the target is already a symbolic link, it fails with the message above. This PR simply modifies `install.sh` by copying the service file instead of making a link.